### PR TITLE
Add discourse.pijul.org to the list of domains

### DIFF
--- a/discourse-dark.user.css
+++ b/discourse-dark.user.css
@@ -14,6 +14,7 @@
 domain("bbs.boingboing.net"),
 domain("community.bevoya.com"),
 domain("community.letsencrypt.org"),
+domain("discourse.pijul.org"),
 domain("discuss.atom.io"),
 domain("discuss.codemirror.net"),
 domain("discuss.elastic.co"),


### PR DESCRIPTION
[Pijul](https://pijul.org) is a DVCS similar to Git.