### PR TITLE
Added community.home-assistant.io

### DIFF
--- a/discourse-dark.user.css
+++ b/discourse-dark.user.css
@@ -14,6 +14,7 @@
 domain("bbs.boingboing.net"),
 domain("community.bevoya.com"),
 domain("community.letsencrypt.org"),
+domain("community.home-assistant.io"),
 domain("discuss.atom.io"),
 domain("discuss.codemirror.net"),
 domain("discuss.elastic.co"),


### PR DESCRIPTION
Adding the forum for Home Assistant, a home automation platform.
[https://community.home-assistant.io/](https://community.home-assistant.io/)