### PR TITLE
Add community.bitwarden.com to list of supported domains

### DIFF
--- a/discourse-dark.user.css
+++ b/discourse-dark.user.css
@@ -14,6 +14,7 @@
 @-moz-document domain("discourse.mozilla.org"),
 domain("bbs.boingboing.net"),
 domain("community.bevoya.com"),
+domain("community.bitwarden.com"),
 domain("community.cloudflare.com"),
 domain("community.letsencrypt.org"),
 domain("community.home-assistant.io"),


### PR DESCRIPTION
Not sure if there's anything else needed so I wanted to PR this instead of just committing to master.

https://community.bitwarden.com