### PR TITLE
Update html tag to also have a black background

### DIFF
--- a/discourse-dark.user.css
+++ b/discourse-dark.user.css
@@ -1,6 +1,6 @@
 /* ==UserStyle==
 @name         Discourse Dark
-@version      1.0.29
+@version      1.0.30
 @description  Darken Discourse forums
 @namespace    StylishThemes
 @author       StylishThemes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "discourse-dark",
   "title": "Discourse Dark",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "description": "Darken Discourse forums",
   "license": "CC-BY-SA-4.0",
   "repository": "https://github.com/StylishThemes/Discourse-Dark",


### PR DESCRIPTION
This fixes the issue where the `body` tag doesn't fill the screen and you're left with a white bar across the bottom. This can be seen at https://www.sitepoint.com/community/t/welcome-to-the-sitepoint-forums/118153/4 by scrolling to the bottom of the page.

I checked https://community.bitwarden.com and their `body` tag has `min-height: 100%;` so this looks to b a per theme issue. I figured it was better to set the color than to adjust the height.